### PR TITLE
Initialize Next.js and NestJS monorepo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,31 @@
-# graphql-sand
+# GraphQL Sand Monorepo
+
+This repository contains a basic monorepo with two applications:
+
+- **web**: a Next.js 14 application using the Pages Router
+- **server**: a NestJS application exposing a simple GraphQL API
+
+## Structure
+
+```
+apps/
+  web/    # Next.js 14 app (Pages Router)
+  server/ # NestJS GraphQL API
+```
+
+## Running the projects
+
+Dependency installation and execution requires Node.js and npm.
+
+```
+# Install dependencies for all workspaces
+npm install
+
+# Start the Next.js app
+npm run --workspace=web dev
+
+# Start the NestJS server in development mode
+npm run --workspace=server start:dev
+```
+
+Each app listens on a different port so you can run them together.

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "server",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "start": "node dist/main.js",
+    "start:dev": "ts-node -r tsconfig-paths/register src/main.ts"
+  },
+  "dependencies": {
+    "@nestjs/common": "^10.0.0",
+    "@nestjs/core": "^10.0.0",
+    "@nestjs/graphql": "^10.0.0",
+    "@nestjs/platform-express": "^10.0.0",
+    "apollo-server-express": "^3.11.1",
+    "graphql": "^16.6.0",
+    "reflect-metadata": "^0.1.13",
+    "rxjs": "^7.8.0"
+  },
+  "devDependencies": {
+    "ts-node": "^10.9.1",
+    "typescript": "^5.2.2",
+    "tsconfig-paths": "^4.1.2"
+  }
+}

--- a/apps/server/src/app.module.ts
+++ b/apps/server/src/app.module.ts
@@ -1,0 +1,15 @@
+import { Module } from '@nestjs/common';
+import { GraphQLModule } from '@nestjs/graphql';
+import { ApolloDriver, ApolloDriverConfig } from '@nestjs/apollo';
+import { AppResolver } from './app.resolver';
+
+@Module({
+  imports: [
+    GraphQLModule.forRoot<ApolloDriverConfig>({
+      driver: ApolloDriver,
+      autoSchemaFile: true,
+    }),
+  ],
+  providers: [AppResolver],
+})
+export class AppModule {}

--- a/apps/server/src/app.resolver.ts
+++ b/apps/server/src/app.resolver.ts
@@ -1,0 +1,9 @@
+import { Query, Resolver } from '@nestjs/graphql';
+
+@Resolver()
+export class AppResolver {
+  @Query(() => String)
+  hello(): string {
+    return 'Hello from NestJS GraphQL!';
+  }
+}

--- a/apps/server/src/main.ts
+++ b/apps/server/src/main.ts
@@ -1,0 +1,8 @@
+import { NestFactory } from '@nestjs/core';
+import { AppModule } from './app.module';
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+  await app.listen(3001);
+}
+bootstrap();

--- a/apps/server/tsconfig.json
+++ b/apps/server/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es2018",
+    "outDir": "dist",
+    "strict": true,
+    "esModuleInterop": true,
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "skipLibCheck": true,
+    "baseUrl": "./",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "web",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "14.0.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  }
+}

--- a/apps/web/pages/index.tsx
+++ b/apps/web/pages/index.tsx
@@ -1,0 +1,3 @@
+export default function Home() {
+  return <div>Hello from Next.js 14 Page Router!</div>;
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "graphql-sand",
+  "private": true,
+  "workspaces": ["apps/*"]
+}


### PR DESCRIPTION
## Summary
- set up a Yarn workspace layout
- add a basic Next.js app using Pages Router
- add a minimal NestJS GraphQL API
- document how to run the apps

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6857a0a9bd18832e94106b7615aaa438