### PR TITLE
Add per-app development guides

### DIFF
--- a/apps/server/README.md
+++ b/apps/server/README.md
@@ -1,0 +1,31 @@
+# Server
+
+This directory contains the NestJS GraphQL server.
+
+## Development
+
+Install dependencies and run the server in watch mode:
+
+```bash
+npm ci
+npm run start:dev
+```
+
+## Data flow
+
+The request/response flow from the GraphQL resolver down to the infrastructure layer is as follows:
+
+```
+[ItemsResolver]        -> handles GraphQL queries
+      |
+      v
+[ItemService]          -> application logic
+      |
+      v
+[ItemRepository]       -> infrastructure access
+      |
+      v
+[in-memory data store] -> returns Item entities
+```
+
+The service converts repository results into the `ItemConnection` type used by the GraphQL API.

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -1,0 +1,12 @@
+# Web
+
+This directory contains the Next.js 14 application.
+
+## Development
+
+Install dependencies and start the dev server:
+
+```bash
+npm ci
+npm run dev
+```


### PR DESCRIPTION
## Summary
- add README for the server with development commands and a resolver->infra flow diagram
- add README for the web app with npm instructions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6857afd1fa84832ea41a998bb30ebd75