### PR TITLE
Add per-app install docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ This repository contains a basic monorepo with two applications:
 - **web**: a Next.js 14 application using the Pages Router
 - **server**: a NestJS application exposing a simple GraphQL API
 
+Each application has its own README in `apps/web` and `apps/server` with instructions specific to that project.
+
 ## Structure
 
 ```
@@ -27,6 +29,8 @@ npm run --workspace=web dev
 # Start the NestJS server in development mode
 npm run --workspace=server start:dev
 ```
+
+Refer to each app's README in `apps/web` or `apps/server` for detailed workflows.
 
 Each app listens on a different port so you can run them together.
 

--- a/apps/server/README.md
+++ b/apps/server/README.md
@@ -1,0 +1,13 @@
+# Server Application
+
+Install dependencies with:
+
+```bash
+npm install
+```
+
+Run the development server:
+
+```bash
+npm run start:dev
+```

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -1,0 +1,13 @@
+# Web Application
+
+Install dependencies with:
+
+```bash
+npm install
+```
+
+Run the development server:
+
+```bash
+npm run dev
+```


### PR DESCRIPTION
## Summary
- note per-app READMEs in root README
- add install instructions for each app using `npm install`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6857b2ea2384832e92dd527fc8f53f6d