### PR TITLE
Add TS setup for web

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+.next/

--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,0 +1,3 @@
+/// <reference types="next" />
+/// <reference types="next/types/global" />
+

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -15,6 +15,10 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@graphql-codegen/cli": "^2.13.1"
+    "@graphql-codegen/cli": "^2.13.1",
+    "@types/node": "^18.19.112",
+    "@types/react": "^19.1.8",
+    "@types/react-dom": "^19.1.6",
+    "typescript": "^5.8.3"
   }
 }

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve"
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,10 @@
       },
       "devDependencies": {
         "@graphql-codegen/cli": "^2.13.1",
-        "@types/react": "19.1.8"
+        "@types/node": "^18.19.112",
+        "@types/react": "^19.1.8",
+        "@types/react-dom": "^19.1.6",
+        "typescript": "^5.8.3"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -2449,6 +2452,16 @@
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.1.6",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.6.tgz",
+      "integrity": "sha512-4hOiT/dwO8Ko0gV1m/TJZYk3y0KBnY9vzDh7W+DH17b2HFSOGgdj33dhihPeuy3l0q23+4e+hoXHV6hCC4dCXw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.0.0"
       }
     },
     "node_modules/@types/send": {


### PR DESCRIPTION
## Summary
- add TypeScript dependencies to `apps/web`
- ignore `.next` build directory
- provide `tsconfig.json` and `next-env.d.ts` for Next.js

## Testing
- `npm --version`


------
https://chatgpt.com/codex/tasks/task_e_6857cb3e0190832ea2ad7f4002395ac5