### PR TITLE
Add InfinteList page with infinite scrolling

### DIFF
--- a/apps/web/components/InfinteList/components.tsx
+++ b/apps/web/components/InfinteList/components.tsx
@@ -1,0 +1,9 @@
+export function InfinteListPresentation({ items }: { items: string[] }) {
+  return (
+    <ul>
+      {items.map((text) => (
+        <li key={text}>{text}</li>
+      ))}
+    </ul>
+  );
+}

--- a/apps/web/components/InfinteList/fragment.ts
+++ b/apps/web/components/InfinteList/fragment.ts
@@ -1,0 +1,8 @@
+import { gql } from "@apollo/client";
+
+export const ITEM_FRAGMENT = gql`
+  fragment ItemFragment on Item {
+    id
+    text
+  }
+`;

--- a/apps/web/components/InfinteList/index.tsx
+++ b/apps/web/components/InfinteList/index.tsx
@@ -1,0 +1,56 @@
+import { useQuery } from "@apollo/client";
+import { useCallback, useEffect, useRef } from "react";
+import { InfinteListPresentation } from "./components";
+import { INFINTE_ITEMS_QUERY } from "../../templates/infinteList";
+
+const PAGE_SIZE = 10;
+
+export default function InfinteList() {
+  const { data, loading, error, fetchMore } = useQuery(INFINTE_ITEMS_QUERY, {
+    variables: { first: PAGE_SIZE },
+    notifyOnNetworkStatusChange: true,
+  });
+
+  const loadMoreRef = useRef<HTMLDivElement | null>(null);
+
+  const handleObserver = useCallback(
+    (entries: IntersectionObserverEntry[]) => {
+      const target = entries[0];
+      if (
+        target.isIntersecting &&
+        data?.items.pageInfo.hasNextPage &&
+        !loading
+      ) {
+        fetchMore({
+          variables: {
+            first: PAGE_SIZE,
+            after: data.items.pageInfo.endCursor,
+          },
+        });
+      }
+    },
+    [data, fetchMore, loading],
+  );
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(handleObserver, {
+      threshold: 1.0,
+    });
+    if (loadMoreRef.current) observer.observe(loadMoreRef.current);
+    return () => {
+      if (loadMoreRef.current) observer.unobserve(loadMoreRef.current);
+    };
+  }, [handleObserver]);
+
+  if (error) return <div>Error loading items</div>;
+
+  const items = data?.items.edges.map((e: any) => e.node.text) ?? [];
+
+  return (
+    <div>
+      <InfinteListPresentation items={items} />
+      {loading && <div>Loading...</div>}
+      <div ref={loadMoreRef} />
+    </div>
+  );
+}

--- a/apps/web/pages/InfinteList/index.tsx
+++ b/apps/web/pages/InfinteList/index.tsx
@@ -1,0 +1,5 @@
+import InfinteList from "../../components/InfinteList";
+
+export default function InfinteListPage() {
+  return <InfinteList />;
+}

--- a/apps/web/templates/infinteList.ts
+++ b/apps/web/templates/infinteList.ts
@@ -1,0 +1,20 @@
+import { gql } from "@apollo/client";
+import { ITEM_FRAGMENT } from "../components/InfinteList/fragment";
+
+export const INFINTE_ITEMS_QUERY = gql`
+  query InfinteItems($first: Int!, $after: String) {
+    items(first: $first, after: $after) {
+      edges {
+        node {
+          ...ItemFragment
+        }
+        cursor
+      }
+      pageInfo {
+        endCursor
+        hasNextPage
+      }
+    }
+  }
+  ${ITEM_FRAGMENT}
+`;


### PR DESCRIPTION
## Summary
- add `InfinteList` component with container/presentation pattern
- define item fragment and query for infinite loading
- create Next.js page at `/InfinteList`

## Testing
- `npm run prettier`

------
https://chatgpt.com/codex/tasks/task_e_6857e50e9978832e8bf5af298017da20