### PR TITLE
Configure cache merge for infinite items

### DIFF
--- a/apps/web/utils/apolloClient.ts
+++ b/apps/web/utils/apolloClient.ts
@@ -1,6 +1,15 @@
 import { ApolloClient, InMemoryCache, HttpLink } from "@apollo/client";
+import { relayStylePagination } from "@apollo/client/utilities";
 
 export const client = new ApolloClient({
   link: new HttpLink({ uri: "http://localhost:3001/graphql" }),
-  cache: new InMemoryCache(),
+  cache: new InMemoryCache({
+    typePolicies: {
+      Query: {
+        fields: {
+          items: relayStylePagination(),
+        },
+      },
+    },
+  }),
 });


### PR DESCRIPTION
## Summary
- add relay style pagination config for items field

## Testing
- `npm run prettier`

------
https://chatgpt.com/codex/tasks/task_e_6857f296a1ec832ebb879b5bc0f09ce2