### PR TITLE
Add keyword-based item prefix

### DIFF
--- a/apps/server/src/application/item.service.ts
+++ b/apps/server/src/application/item.service.ts
@@ -29,8 +29,8 @@ export class ItemConnection {
 export class ItemService {
   constructor(private readonly repo: ItemRepository) {}
 
-  getItems(first: number, after?: string): ItemConnection {
-    const { items, hasNextPage } = this.repo.fetch(first, after);
+  getItems(first: number, keyword: string, after?: string): ItemConnection {
+    const { items, hasNextPage } = this.repo.fetch(first, after, keyword);
     const edges = items.map((i) => ({ node: i, cursor: i.id }));
     const endCursor =
       edges.length > 0 ? edges[edges.length - 1].cursor : undefined;

--- a/apps/server/src/infrastructure/item.repository.ts
+++ b/apps/server/src/infrastructure/item.repository.ts
@@ -6,7 +6,7 @@ export class ItemRepository {
     text: `Item ${i + 1}`,
   }));
 
-  fetch(first: number, after?: string) {
+  fetch(first: number, after: string | undefined, keyword: string) {
     let start = 0;
     if (after) {
       const index = this.data.findIndex((i) => i.id === after);
@@ -14,7 +14,10 @@ export class ItemRepository {
         start = index + 1;
       }
     }
-    const items = this.data.slice(start, start + first);
+    const items = this.data.slice(start, start + first).map((i) => ({
+      ...i,
+      text: `${keyword}${i.id}`,
+    }));
     const hasNextPage = start + first < this.data.length;
     return { items, hasNextPage };
   }

--- a/apps/server/src/presentation/items/items.graphql
+++ b/apps/server/src/presentation/items/items.graphql
@@ -19,5 +19,5 @@ type ItemConnection {
 }
 
 type Query {
-  items(first: Int!, after: String): ItemConnection!
+  items(first: Int!, keyword: String!, after: String): ItemConnection!
 }

--- a/apps/server/src/presentation/items/items.resolver.ts
+++ b/apps/server/src/presentation/items/items.resolver.ts
@@ -9,8 +9,9 @@ export class ItemsResolver {
   @Query(() => ItemConnection)
   items(
     @Args("first", { type: () => Int }) first: number,
+    @Args("keyword", { type: () => String }) keyword: string,
     @Args("after", { nullable: true }) after?: string,
   ) {
-    return this.service.getItems(first, after);
+    return this.service.getItems(first, keyword, after);
   }
 }

--- a/apps/web/components/InfiniteList/index.tsx
+++ b/apps/web/components/InfiniteList/index.tsx
@@ -1,13 +1,14 @@
 import { useQuery } from "@apollo/client";
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { InfiniteListPresentation } from "./components";
 import { INFINITE_ITEMS_QUERY } from "../../templates/infiniteList";
 
 const PAGE_SIZE = 10;
 
 export default function InfiniteList() {
+  const [keyword, setKeyword] = useState("item");
   const { data, loading, error, fetchMore } = useQuery(INFINITE_ITEMS_QUERY, {
-    variables: { first: PAGE_SIZE },
+    variables: { first: PAGE_SIZE, keyword },
     notifyOnNetworkStatusChange: true,
   });
 
@@ -24,12 +25,13 @@ export default function InfiniteList() {
         fetchMore({
           variables: {
             first: PAGE_SIZE,
+            keyword,
             after: data.items.pageInfo.endCursor,
           },
         });
       }
     },
-    [data, fetchMore, loading],
+    [data, fetchMore, loading, keyword],
   );
 
   useEffect(() => {
@@ -48,6 +50,11 @@ export default function InfiniteList() {
 
   return (
     <div>
+      <input
+        value={keyword}
+        onChange={(e) => setKeyword(e.target.value.slice(0, 5))}
+        placeholder="keyword"
+      />
       <InfiniteListPresentation items={items} />
       {loading && <div>Loading...</div>}
       <div ref={loadMoreRef} />

--- a/apps/web/templates/infiniteList.ts
+++ b/apps/web/templates/infiniteList.ts
@@ -1,8 +1,8 @@
 import { gql } from "@apollo/client";
 import { ITEM_FRAGMENT } from "../components/InfiniteList/fragment";
 export const INFINITE_ITEMS_QUERY = gql`
-  query InfiniteItems($first: Int!, $after: String) {
-    items(first: $first, after: $after) {
+  query InfiniteItems($first: Int!, $keyword: String!, $after: String) {
+    items(first: $first, keyword: $keyword, after: $after) {
       edges {
         node {
           ...ItemFragment


### PR DESCRIPTION
## Summary
- allow passing `keyword` to the `items` query
- generate repository items using the provided keyword
- send the keyword from the InfiniteList component
- update GraphQL query for the new argument

## Testing
- `npm run prettier`
- `npm run --workspace=server codegen` *(fails: Invalid Custom Plugin)*
- `npm run --workspace=web codegen` *(fails: Unable to find template plugin)*

------
https://chatgpt.com/codex/tasks/task_e_6858108511c8832ebece2968abeb09cc