### PR TITLE
Add search confirmation for InfiniteList

### DIFF
--- a/apps/web/utils/apolloClient.ts
+++ b/apps/web/utils/apolloClient.ts
@@ -7,7 +7,7 @@ export const client = new ApolloClient({
     typePolicies: {
       Query: {
         fields: {
-          items: relayStylePagination(),
+          items: relayStylePagination(["keyword"]),
         },
       },
     },


### PR DESCRIPTION
## Summary
- add explicit search button for InfiniteList
- reset items cache and refetch when confirming search
- key items cache by keyword

## Testing
- `npm run prettier`

------
https://chatgpt.com/codex/tasks/task_e_685812ea1c18832e9bef4f83f8f2fbb5