### PR TITLE
Fix item caching issue

### DIFF
--- a/apps/web/components/InfiniteList/index.tsx
+++ b/apps/web/components/InfiniteList/index.tsx
@@ -12,6 +12,7 @@ export default function InfiniteList() {
     INFINITE_ITEMS_QUERY,
     {
       variables: { first: PAGE_SIZE, keyword: queryKeyword },
+      fetchPolicy: "cache-first",
       notifyOnNetworkStatusChange: true,
     },
   );
@@ -19,8 +20,6 @@ export default function InfiniteList() {
   const loadMoreRef = useRef<HTMLDivElement | null>(null);
 
   const handleSearch = useCallback(() => {
-    client.cache.evict({ fieldName: "items" });
-    client.cache.gc();
     setQueryKeyword(keyword);
   }, [client, keyword]);
 

--- a/apps/web/components/InfiniteList/index.tsx
+++ b/apps/web/components/InfiniteList/index.tsx
@@ -12,6 +12,7 @@ export default function InfiniteList() {
     INFINITE_ITEMS_QUERY,
     {
       variables: { first: PAGE_SIZE, keyword: queryKeyword },
+      // 同じキーワードで再検索した際はキャッシュを優先して再利用する
       fetchPolicy: "cache-first",
       notifyOnNetworkStatusChange: true,
     },
@@ -20,6 +21,7 @@ export default function InfiniteList() {
   const loadMoreRef = useRef<HTMLDivElement | null>(null);
 
   const handleSearch = useCallback(() => {
+    // 検索文字列を更新するだけでキャッシュを保持する
     setQueryKeyword(keyword);
   }, [client, keyword]);
 

--- a/apps/web/utils/apolloClient.ts
+++ b/apps/web/utils/apolloClient.ts
@@ -10,6 +10,9 @@ export const client = new ApolloClient({
           items: relayStylePagination(["keyword"]),
         },
       },
+      Item: {
+        keyFields: false,
+      },
     },
   }),
 });

--- a/apps/web/utils/apolloClient.ts
+++ b/apps/web/utils/apolloClient.ts
@@ -10,6 +10,8 @@ export const client = new ApolloClient({
           items: relayStylePagination(["keyword"]),
         },
       },
+      // アイテムはキーワードごとに別物として扱いたいため
+      // keyFields を無効化して Apollo の正規化キャッシュを避ける
       Item: {
         keyFields: false,
       },


### PR DESCRIPTION
## Summary
- disable normalization for `Item` objects to avoid cross-keyword text mismatches

## Testing
- `npm test` *(fails: Missing script)*
- `npm run prettier`


------
https://chatgpt.com/codex/tasks/task_e_68581815b2c4832eb1bcaf4b9eab014b