### PR TITLE
Add detail fields to items and expand list UI

### DIFF
--- a/apps/server/src/domain/item.entity.ts
+++ b/apps/server/src/domain/item.entity.ts
@@ -7,4 +7,10 @@ export class Item {
 
   @Field()
   text!: string;
+
+  @Field()
+  name!: string;
+
+  @Field()
+  address!: string;
 }

--- a/apps/server/src/infrastructure/item.repository.ts
+++ b/apps/server/src/infrastructure/item.repository.ts
@@ -4,6 +4,8 @@ export class ItemRepository {
   private data: Item[] = Array.from({ length: 50 }, (_, i) => ({
     id: String(i + 1),
     text: `Item ${i + 1}`,
+    name: `Name ${i + 1}`,
+    address: `Address ${i + 1}`,
   }));
 
   fetch(first: number, after: string | undefined, keyword: string) {

--- a/apps/server/src/presentation/items/items.graphql
+++ b/apps/server/src/presentation/items/items.graphql
@@ -1,6 +1,8 @@
 type Item {
   id: ID!
   text: String!
+  name: String!
+  address: String!
 }
 
 type ItemEdge {

--- a/apps/web/components/InfiniteList/components.tsx
+++ b/apps/web/components/InfiniteList/components.tsx
@@ -1,8 +1,31 @@
-export function InfiniteListPresentation({ items }: { items: string[] }) {
+export interface DisplayItem {
+  id: string;
+  text: string;
+  name: string;
+  address: string;
+}
+
+export function InfiniteListPresentation({
+  items,
+  expandedId,
+  onItemClick,
+}: {
+  items: DisplayItem[];
+  expandedId?: string;
+  onItemClick: (id: string) => void;
+}) {
   return (
     <ul>
-      {items.map((text) => (
-        <li key={text}>{text}</li>
+      {items.map((item) => (
+        <li key={item.id}>
+          <div onClick={() => onItemClick(item.id)}>{item.text}</div>
+          {expandedId === item.id && (
+            <div>
+              <div>{item.name}</div>
+              <div>{item.address}</div>
+            </div>
+          )}
+        </li>
       ))}
     </ul>
   );

--- a/apps/web/components/InfiniteList/fragment.ts
+++ b/apps/web/components/InfiniteList/fragment.ts
@@ -4,5 +4,7 @@ export const ITEM_FRAGMENT = gql`
   fragment ItemFragment on Item {
     id
     text
+    name
+    address
   }
 `;

--- a/apps/web/components/InfiniteList/index.tsx
+++ b/apps/web/components/InfiniteList/index.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from "@apollo/client";
 import { useCallback, useEffect, useRef, useState } from "react";
-import { InfiniteListPresentation } from "./components";
+import { InfiniteListPresentation, DisplayItem } from "./components";
 import { INFINITE_ITEMS_QUERY } from "../../templates/infiniteList";
 
 const PAGE_SIZE = 10;
@@ -8,6 +8,7 @@ const PAGE_SIZE = 10;
 export default function InfiniteList() {
   const [keyword, setKeyword] = useState("item");
   const [queryKeyword, setQueryKeyword] = useState("item");
+  const [expandedId, setExpandedId] = useState<string>();
   const { data, loading, error, fetchMore, client } = useQuery(
     INFINITE_ITEMS_QUERY,
     {
@@ -57,7 +58,11 @@ export default function InfiniteList() {
 
   if (error) return <div>Error loading items</div>;
 
-  const items = data?.items.edges.map((e: any) => e.node.text) ?? [];
+  const items: DisplayItem[] = data?.items.edges.map((e: any) => e.node) ?? [];
+
+  const handleClick = useCallback((id: string) => {
+    setExpandedId((prev) => (prev === id ? undefined : id));
+  }, []);
 
   return (
     <div>
@@ -67,7 +72,11 @@ export default function InfiniteList() {
         placeholder="keyword"
       />
       <button onClick={handleSearch}>Search</button>
-      <InfiniteListPresentation items={items} />
+      <InfiniteListPresentation
+        items={items}
+        expandedId={expandedId}
+        onItemClick={handleClick}
+      />
       {loading && <div>Loading...</div>}
       <div ref={loadMoreRef} />
     </div>


### PR DESCRIPTION
## Summary
- extend `Item` entity to include `name` and `address`
- expose new fields in GraphQL schema and repository data
- update `ItemFragment` and InfiniteList components
- allow clicking items to show their details

## Testing
- `npm run prettier`

------
https://chatgpt.com/codex/tasks/task_e_685829a0c614832e9c53fcf5c54b12c4