### PR TITLE
Fix early return causing hook mismatch

### DIFF
--- a/apps/web/components/InfiniteList/index.tsx
+++ b/apps/web/components/InfiniteList/index.tsx
@@ -56,13 +56,13 @@ export default function InfiniteList() {
     };
   }, [handleObserver]);
 
-  if (error) return <div>Error loading items</div>;
-
-  const items: DisplayItem[] = data?.items.edges.map((e: any) => e.node) ?? [];
-
   const handleClick = useCallback((id: string) => {
     setExpandedId((prev) => (prev === id ? undefined : id));
   }, []);
+
+  if (error) return <div>Error loading items</div>;
+
+  const items: DisplayItem[] = data?.items.edges.map((e: any) => e.node) ?? [];
 
   return (
     <div>


### PR DESCRIPTION
## Summary
- ensure InfiniteList defines hooks before any early return to avoid React hook count errors

## Testing
- `npm run prettier`


------
https://chatgpt.com/codex/tasks/task_e_68582b490c40832e8cc35a131e73b402